### PR TITLE
🚨 [URGENT] Home: surface "Connect your agent" nudge for single-VM users

### DIFF
--- a/app/new-navbar/(tabs)/index.tsx
+++ b/app/new-navbar/(tabs)/index.tsx
@@ -19,6 +19,9 @@ import {
   MachineCarousel,
 } from "@/components/new-navbar/MachineCarousel";
 import { NewChatSlider2 } from "@/components/new-navbar/NewChatSlider2";
+import { claudeStatus } from "@/api/claude";
+import { opencodeStatus } from "@/api/opencode";
+import { getToken } from "@/store/auth-store";
 import { posthog } from "@/constants/posthog";
 import { VM_ICONS } from "@/constants/vm-icons";
 import { extractHost, useNavbar } from "@/contexts/navbar-context";
@@ -130,6 +133,8 @@ export default function HomeScreen() {
   >({});
   const [grassVmName, setGrassVmName] = useState<string | null>(null);
   const hasPromptedForName = useRef(false);
+  // null = not yet known; true/false = confirmed. Drives the "Connect your agent" nudge.
+  const [agentConnected, setAgentConnected] = useState<boolean | null>(null);
 
   const {
     vmUrls,
@@ -158,14 +163,55 @@ export default function HomeScreen() {
     return unsub;
   }, [selectedVmUrl]);
 
+  // Avoid state updates after unmount (fetch can resolve after navigating away).
+  const isMounted = useRef(true);
+  useEffect(() => () => { isMounted.current = false; }, []);
+
+  // Fetch agent-connection status (account-wide) and update the nudge. Used both on
+  // focus and whenever the Connect slider closes. To "confirm none connected" we
+  // require BOTH status calls to succeed; if either fails we leave `agentConnected`
+  // unchanged so the nudge stays hidden rather than flashing for someone whose
+  // (possibly connected) agent simply failed to report.
+  const refreshAgentStatus = React.useCallback(async () => {
+    const token = await getToken();
+    if (!token) return;
+    const [claudeRes, opencodeRes] = await Promise.all([
+      claudeStatus(token),
+      opencodeStatus(token),
+    ]);
+    if (!isMounted.current) return;
+    const anyConnected =
+      (claudeRes.ok && claudeRes.data.connected) ||
+      (opencodeRes.ok && opencodeRes.data.connected);
+    if (anyConnected) {
+      setAgentConnected(true);
+    } else if (claudeRes.ok && opencodeRes.ok) {
+      // Both reported successfully and neither is connected.
+      setAgentConnected(false);
+    }
+    // else: at least one call failed and none confirmed connected → leave unknown.
+  }, []);
+
   useFocusEffect(
     React.useCallback(() => {
       if (selectedVmUrl) setSessionStatuses(getSessionStatuses(selectedVmUrl));
       getAllVmMetadata().then(setVmMetadataMap);
       notifyWakeTabFocus();
+      refreshAgentStatus();
       return () => notifyWakeTabBlur();
-    }, [selectedVmUrl, notifyWakeTabFocus, notifyWakeTabBlur])
+    }, [selectedVmUrl, notifyWakeTabFocus, notifyWakeTabBlur, refreshAgentStatus])
   );
+
+  // The Connect slider opens on top of the home screen (no navigation), so the focus
+  // effect won't re-run. Re-check agent status when it closes to update the nudge
+  // right after a connect/disconnect.
+  const wasConnectMoreVisible = useRef(connectMoreVisible);
+  useEffect(() => {
+    if (wasConnectMoreVisible.current && !connectMoreVisible) {
+      refreshAgentStatus();
+    }
+    wasConnectMoreVisible.current = connectMoreVisible;
+  }, [connectMoreVisible, refreshAgentStatus]);
 
   // Load stored names + icons whenever the VM list changes
   useEffect(() => {
@@ -253,8 +299,10 @@ export default function HomeScreen() {
   const isLoading = vmUrls.length === 0;
   const onPrimaryVm = !!primaryVmUrl && selectedVmUrl === primaryVmUrl;
 
-  // Only the default Grass VM is connected — nudge the user to connect their own agent.
-  const showConnectAgent = vmUrls.length === 1;
+  // No coding agent (Claude Code / Opencode) connected yet — nudge the user to connect one.
+  // `agentConnected` stays null until a status fetch resolves, so the nudge only appears
+  // once we've confirmed none is connected.
+  const showConnectAgent = agentConnected === false;
 
   function renderThreadList() {
     if (FORCE_SKELETON_PREVIEW || isLoading || (onPrimaryVm && !vmRunning)) {

--- a/app/new-navbar/(tabs)/index.tsx
+++ b/app/new-navbar/(tabs)/index.tsx
@@ -253,6 +253,9 @@ export default function HomeScreen() {
   const isLoading = vmUrls.length === 0;
   const onPrimaryVm = !!primaryVmUrl && selectedVmUrl === primaryVmUrl;
 
+  // Only the default Grass VM is connected — nudge the user to connect their own agent.
+  const showConnectAgent = vmUrls.length === 1;
+
   function renderThreadList() {
     if (FORCE_SKELETON_PREVIEW || isLoading || (onPrimaryVm && !vmRunning)) {
       return Array.from({ length: 20 }).map((_, i) => (
@@ -386,6 +389,20 @@ export default function HomeScreen() {
         onClose={() => setNewChatVisible(false)}
       />
 
+      {/* ── Connect-agent nudge (only default Grass VM connected) ── */}
+      {showConnectAgent && (
+        <View style={styles.connectAgentCard}>
+          <Text style={styles.connectAgentText}>Connect your agent</Text>
+          <TouchableOpacity
+            style={styles.connectAgentButton}
+            activeOpacity={0.85}
+            onPress={() => setConnectMoreVisible(true)}
+          >
+            <Text style={styles.connectAgentButtonText}>Connect</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
       {/* ── Section header ── */}
       <View style={styles.sectionHeaderRow}>
         <Text style={styles.sectionHeader}>Recent threads</Text>
@@ -461,6 +478,37 @@ const styles = StyleSheet.create({
     fontFamily: SFPro.medium,
     fontSize: 14,
     color: "#3D841E",
+  },
+  connectAgentCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: 16,
+    marginHorizontal: 16,
+    paddingVertical: 12,
+    paddingLeft: 16,
+    paddingRight: 12,
+    backgroundColor: "#E3FDD7",
+    borderRadius: 14,
+    borderCurve: "continuous",
+    borderWidth: 1,
+    borderColor: "#72C44E",
+  },
+  connectAgentText: {
+    fontFamily: SFPro.semiBold,
+    fontSize: 15,
+    color: "#2A5C14",
+  },
+  connectAgentButton: {
+    backgroundColor: "#3D841E",
+    borderRadius: 999,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  connectAgentButtonText: {
+    fontFamily: SFPro.semiBold,
+    fontSize: 14,
+    color: "#FFFFFF",
   },
   sectionHeaderRow: {
     flexDirection: "row",

--- a/components/new-navbar/ConnectLaptopSlider.tsx
+++ b/components/new-navbar/ConnectLaptopSlider.tsx
@@ -2,6 +2,7 @@ import {
   BottomSheetBackdrop,
   BottomSheetModal,
   BottomSheetScrollView,
+  BottomSheetTextInput,
   useBottomSheetTimingConfigs,
 } from "@gorhom/bottom-sheet";
 import { CameraView, useCameraPermissions } from "expo-camera";
@@ -10,13 +11,10 @@ import {
   Alert,
   Clipboard,
   Keyboard,
-  KeyboardAvoidingView,
   Linking,
-  Platform,
   ScrollView,
   StyleSheet,
   Text,
-  TextInput,
   TouchableOpacity,
   View,
 } from "react-native";
@@ -60,6 +58,8 @@ export function ConnectLaptopSlider({ visible, onClose }: Props) {
   const [machineName, setMachineName] = useState("");
   const [selectedIconIndex, setSelectedIconIndex] = useState(0);
   const [scannedUrl, setScannedUrl] = useState("");
+  const [showManualInput, setShowManualInput] = useState(false);
+  const [manualUrl, setManualUrl] = useState("");
 
   const snapPoints = ["90%"];
   const animationConfigs = useBottomSheetTimingConfigs({
@@ -112,6 +112,8 @@ export function ConnectLaptopSlider({ visible, onClose }: Props) {
       setStep("scan");
       setMachineName("");
       setSelectedIconIndex(0);
+      setShowManualInput(false);
+      setManualUrl("");
     } else {
       bottomSheetRef.current?.dismiss();
     }
@@ -156,6 +158,24 @@ export function ConnectLaptopSlider({ visible, onClose }: Props) {
     }
   }, [cameraPermission, requestCameraPermission]);
 
+  const handleManualSubmit = useCallback(() => {
+    const url = manualUrl.trim();
+    if (!url) return;
+    if (!/^https?:\/\//i.test(url)) {
+      Alert.alert(
+        "Invalid URL",
+        "The URL must start with http:// or https://.",
+      );
+      return;
+    }
+    Keyboard.dismiss();
+    setScannedUrl(url);
+    setCameraEnabled(false);
+    setShowManualInput(false);
+    setManualUrl("");
+    slideSuccessIn("paired");
+  }, [manualUrl, slideSuccessIn]);
+
   const isGreenStep = step === "paired" || step === "ready";
   const SelectedIconComponent = ICONS[selectedIconIndex];
 
@@ -164,6 +184,9 @@ export function ConnectLaptopSlider({ visible, onClose }: Props) {
       ref={bottomSheetRef}
       snapPoints={snapPoints}
       enablePanDownToClose
+      keyboardBehavior="interactive"
+      keyboardBlurBehavior="restore"
+      android_keyboardInputMode="adjustResize"
       animationConfigs={animationConfigs}
       backdropComponent={renderBackdrop}
       onDismiss={() => {
@@ -263,6 +286,47 @@ export function ConnectLaptopSlider({ visible, onClose }: Props) {
                   </TouchableOpacity>
                 )}
               </View>
+
+              {showManualInput ? (
+                <View style={styles.manualInputContainer}>
+                  <BottomSheetTextInput
+                    style={styles.manualInput}
+                    placeholder="https://your-machine-url"
+                    placeholderTextColor="#888"
+                    value={manualUrl}
+                    onChangeText={setManualUrl}
+                    autoFocus
+                    selectTextOnFocus
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    keyboardType="url"
+                    returnKeyType="go"
+                    onSubmitEditing={handleManualSubmit}
+                  />
+                  <TouchableOpacity
+                    style={[
+                      styles.manualSubmitButton,
+                      manualUrl.trim()
+                        ? styles.manualSubmitActive
+                        : styles.manualSubmitInactive,
+                    ]}
+                    onPress={handleManualSubmit}
+                    activeOpacity={manualUrl.trim() ? 0.85 : 1}
+                  >
+                    <Text style={styles.manualSubmitText}>Use this link</Text>
+                  </TouchableOpacity>
+                </View>
+              ) : (
+                <TouchableOpacity
+                  style={styles.manualToggle}
+                  onPress={() => setShowManualInput(true)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.manualToggleText}>
+                    Or enter the URL manually
+                  </Text>
+                </TouchableOpacity>
+              )}
             </View>
 
             <View style={styles.footerSection}>
@@ -282,10 +346,7 @@ export function ConnectLaptopSlider({ visible, onClose }: Props) {
 
       {/* ── Setup step ── */}
       {step === "setup" && (
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-        >
+        <>
           <View style={styles.header}>
             <View style={styles.headerText}>
               <Text style={styles.headerTitle}>Set up this machine</Text>
@@ -295,7 +356,7 @@ export function ConnectLaptopSlider({ visible, onClose }: Props) {
             </View>
           </View>
 
-          <ScrollView
+          <BottomSheetScrollView
             showsVerticalScrollIndicator={false}
             contentContainerStyle={styles.setupScrollContent}
             bounces={false}
@@ -336,7 +397,7 @@ export function ConnectLaptopSlider({ visible, onClose }: Props) {
             </ScrollView>
 
             <View style={styles.nameInputContainer}>
-              <TextInput
+              <BottomSheetTextInput
                 style={styles.nameInput}
                 placeholder="Work Laptop"
                 placeholderTextColor="#888"
@@ -375,8 +436,8 @@ export function ConnectLaptopSlider({ visible, onClose }: Props) {
             >
               <Text style={styles.saveButtonText}>Save</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
+          </BottomSheetScrollView>
+        </>
       )}
 
       {/* ── Green success overlay (paired + ready) ── */}
@@ -608,6 +669,51 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: "#888",
     letterSpacing: -0.2,
+  },
+  manualToggle: {
+    alignItems: "center",
+    paddingVertical: 8,
+  },
+  manualToggleText: {
+    fontFamily: SFPro.semiBold,
+    fontSize: 14,
+    color: "#3D841E",
+    letterSpacing: -0.2,
+  },
+  manualInputContainer: {
+    gap: 10,
+  },
+  manualInput: {
+    fontFamily: SFMono.medium,
+    fontSize: 15,
+    color: "#000",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#DFDFDF",
+    backgroundColor: "#F2F2F2",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    letterSpacing: -0.2,
+  },
+  manualSubmitButton: {
+    borderRadius: 50,
+    paddingVertical: 14,
+    alignItems: "center",
+    borderWidth: 2,
+  },
+  manualSubmitActive: {
+    borderColor: "#72C44E",
+    backgroundColor: "#3D841E",
+  },
+  manualSubmitInactive: {
+    borderColor: "#808080",
+    backgroundColor: "#9F9F9F",
+  },
+  manualSubmitText: {
+    fontFamily: SFPro.semiBold,
+    fontSize: 15,
+    color: "#FFF",
+    letterSpacing: -0.3,
   },
   footerSection: {
     alignItems: "center",


### PR DESCRIPTION
## What & why
Users who've only got the default Grass VM (no agent/laptop connected) had no clear prompt to connect more. This adds a nudge on the Home screen to drive agent connections.

## Changes
- Add a "Connect your agent" container on the Home screen, shown only when exactly one machine is connected (the default Grass VM). Hidden while loading and once any additional agent/laptop is connected.
- Placed between the machine carousel and the "Recent threads" section.
- Its "Connect" button opens the existing "Get more from grass" sheet.

No new dependencies; reuses existing ConnectMoreSlider and green palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)