### PR TITLE
VM activation flow: name → activate → live (real provisioning)

### DIFF
--- a/app/onboarding/vm-ready.tsx
+++ b/app/onboarding/vm-ready.tsx
@@ -1,7 +1,13 @@
-import BackButton from "@/assets/images/new-design/chat/back-button.svg";
+import { isSandboxUsageLimitError } from "@/api/client";
+import { heartbeat, requestContainer, signedPreviewUrl } from "@/api/containers";
 import { Confetti } from "@/components/onboarding/Confetti";
+import { DotMatrixLoader } from "@/components/onboarding/DotMatrixLoader";
 import { ServerTerminal } from "@/components/onboarding/ServerTerminal";
+import { posthog } from "@/constants/posthog";
 import { SFPro } from "@/constants/theme";
+import { getToken } from "@/store/auth-store";
+import { notifyGrassSandboxUsageLimitHit, notifyGrassVmReady } from "@/store/grass-vm-events";
+import { saveVmUrl } from "@/store/url-store";
 import { setVmName as saveVmName } from "@/store/vm-metadata-store";
 import { LinearGradient } from "expo-linear-gradient";
 import { Stack, useRouter } from "expo-router";
@@ -29,11 +35,63 @@ const ACTIVATE_SHIFT = SCREEN_HEIGHT * 0.12; // down to centre when activating
 type Phase = "naming" | "activating" | "live";
 
 const LOADING_MSGS = [
-  "Spinning up your machine…",
-  "Allocating compute…",
-  "Booting things up…",
-  "Almost there…",
+  "Securing your plot…",
+  "Waking the CPU…",
+  "Watering the server…",
+  "Planting seeds…",
+  "Checking the soil…",
+  "Allocating sunlight…",
+  "Greening the terminal…",
+  "Roots are taking hold…",
+  "Pruning the latency…",
+  "Almost ready to grow.",
 ];
+
+// Keep the activation animation on screen at least this long, even if the
+// container is already running and the backend resolves near-instantly.
+const ACTIVATING_MIN_MS = 2600;
+
+// A soft sheen that sweeps across the loading text. On the white background the
+// white band only shows where it overlaps the (darker) glyphs, reading as shimmer.
+function ShimmerText({ text }: { text: string }) {
+  const tx = useRef(new Animated.Value(0)).current;
+  const [width, setWidth] = useState(0);
+  const BAND = 90;
+
+  useEffect(() => {
+    if (!width) return;
+    tx.setValue(-BAND);
+    const anim = Animated.loop(
+      Animated.timing(tx, {
+        toValue: width + BAND,
+        duration: 2000,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      }),
+    );
+    anim.start();
+    return () => anim.stop();
+  }, [width, tx]);
+
+  return (
+    <View onLayout={(e) => setWidth(e.nativeEvent.layout.width)}>
+      <Text style={styles.loadingText}>{text}</Text>
+      {width > 0 && (
+        <Animated.View
+          pointerEvents="none"
+          style={[StyleSheet.absoluteFill, { transform: [{ translateX: tx }] }]}
+        >
+          <LinearGradient
+            colors={["#FFFFFF00", "#FFFFFFF2", "#FFFFFF00"]}
+            start={{ x: 0, y: 0.5 }}
+            end={{ x: 1, y: 0.5 }}
+            style={{ width: BAND, height: "100%" }}
+          />
+        </Animated.View>
+      )}
+    </View>
+  );
+}
 
 export default function VmReadyScreen() {
   const router = useRouter();
@@ -43,6 +101,9 @@ export default function VmReadyScreen() {
   const [loadingStep, setLoadingStep] = useState(0);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const [serverUrl, setServerUrl] = useState<string | undefined>(undefined);
+  const [provisionError, setProvisionError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
 
   const scale = useRef(new Animated.Value(1)).current;
   const colorAnim = useRef(new Animated.Value(0)).current;
@@ -87,7 +148,7 @@ export default function VmReadyScreen() {
     if (phase === "live") setMood("excited");
   }, [phase]);
 
-  // Loading sequence while "activating", then flip to "live".
+  // Cycle the loading messages while "activating".
   useEffect(() => {
     if (phase !== "activating") return;
     setLoadingStep(0);
@@ -95,19 +156,111 @@ export default function VmReadyScreen() {
     const interval = setInterval(() => {
       step += 1;
       setLoadingStep(step % LOADING_MSGS.length);
-    }, 850);
-    const done = setTimeout(() => setPhase("live"), 3200);
-    return () => {
-      clearInterval(interval);
-      clearTimeout(done);
-    };
+    }, 2000);
+    return () => clearInterval(interval);
   }, [phase]);
+
+  // Real container provisioning while "activating" — mirrors vm-final's logic.
+  // Flips to "live" only once the backend confirms the VM is ready (and the
+  // activation animation has had at least ACTIVATING_MIN_MS on screen).
+  useEffect(() => {
+    if (phase !== "activating") return;
+    let cancelled = false;
+    const startedAt = Date.now();
+
+    const goLive = async (url?: string) => {
+      if (cancelled) return;
+      if (url) await saveVmUrl(url);
+      setServerUrl(url);
+      notifyGrassVmReady();
+      posthog.capture("vm_provisioned", { vm_name: name.trim() });
+      const wait = Math.max(0, ACTIVATING_MIN_MS - (Date.now() - startedAt));
+      setTimeout(() => {
+        if (!cancelled) setPhase("live");
+      }, wait);
+    };
+
+    async function provision() {
+      const token = await getToken();
+      if (!token || cancelled) return;
+
+      // 1. Heartbeat — container may already be running.
+      const hb = await heartbeat(token);
+      if (cancelled) return;
+
+      if (!hb.ok && isSandboxUsageLimitError(hb)) {
+        notifyGrassSandboxUsageLimitHit();
+        router.replace("/new-navbar/(tabs)" as any);
+        return;
+      }
+
+      if (hb.ok && hb.data.container === "running" && hb.data.grass) {
+        let url = hb.data.url;
+        if (!url) {
+          const preview = await signedPreviewUrl(token);
+          if (preview.ok) url = preview.data.url;
+        }
+        await goLive(url);
+        return;
+      }
+
+      // 2. Provisioning in progress — poll every 2s for up to 10s.
+      if (hb.ok && hb.data.container === "provisioning") {
+        const pollStart = Date.now();
+        while (Date.now() - pollStart < 10000) {
+          await new Promise((r) => setTimeout(r, 2000));
+          if (cancelled) return;
+          const poll = await heartbeat(token);
+          if (cancelled) return;
+          if (!poll.ok && isSandboxUsageLimitError(poll)) {
+            notifyGrassSandboxUsageLimitHit();
+            router.replace("/new-navbar/(tabs)" as any);
+            return;
+          }
+          if (poll.ok && poll.data.container === "running" && poll.data.grass) {
+            let url = poll.data.url;
+            if (!url) {
+              const preview = await signedPreviewUrl(token);
+              if (preview.ok) url = preview.data.url;
+            }
+            await goLive(url);
+            return;
+          }
+          if (poll.ok && poll.data.container !== "provisioning") break;
+        }
+      }
+
+      if (cancelled) return;
+
+      // 3. Container stopped / not found — request / restart it.
+      const result = await requestContainer(token);
+      if (cancelled) return;
+
+      if (result.ok) {
+        posthog.capture("container_provisioned");
+        await goLive(result.data.url);
+      } else if (isSandboxUsageLimitError(result)) {
+        posthog.capture("container_provision_failed", { reason: "sandbox_limit" });
+        notifyGrassSandboxUsageLimitHit();
+        router.replace("/new-navbar/(tabs)" as any);
+      } else {
+        posthog.capture("container_provision_failed", { reason: result.error });
+        setProvisionError(result.error);
+      }
+    }
+
+    provision();
+    return () => {
+      cancelled = true;
+    };
+  }, [phase, retryCount, name, router]);
 
   const handleActivate = async () => {
     const trimmed = name.trim();
     if (!trimmed) return;
     Keyboard.dismiss();
     await saveVmName(trimmed);
+    setProvisionError(null);
     setPhase("activating");
     setMood("excited");
     Animated.timing(activate, {
@@ -131,7 +284,16 @@ export default function VmReadyScreen() {
   };
 
   const handleLiveContinue = () => {
-    router.replace({ pathname: "/onboarding/vm-final" as any, params: { vmName: name.trim() } });
+    router.push({
+      pathname: "/onboarding/vm-first-task" as any,
+      params: { vmName: name.trim(), serverUrl: serverUrl ?? "" },
+    });
+  };
+
+  const handleRetry = () => {
+    setProvisionError(null);
+    setMood("waiting");
+    setRetryCount((c) => c + 1);
   };
 
   const backgroundColor = colorAnim.interpolate({
@@ -232,29 +394,56 @@ export default function VmReadyScreen() {
           pointerEvents={phase === "naming" ? "none" : "auto"}
           style={[StyleSheet.absoluteFill, { opacity: activateOpacity }]}
         >
-          {phase === "live" && (
+          {phase !== "naming" && (
             <SafeAreaView style={styles.backSafe}>
-              {/* TEMP back button */}
+              {/* TEMP back button — also shown while activating so we can bail
+                  out of the loading loop until the backend is fixed. */}
               <Pressable style={styles.backBtn} hitSlop={10} onPress={handleBack}>
-                <BackButton />
+                <Text style={styles.backText}>‹ Back</Text>
               </Pressable>
             </SafeAreaView>
           )}
 
           <Text style={styles.liveTitle}>
-            {phase === "live" ? `${name} is live!` : "Activating your machine"}
+            {phase === "live"
+              ? `${name} is live!`
+              : provisionError
+                ? "Couldn't start your machine"
+                : "Activating your machine"}
           </Text>
 
           {phase === "live" ? (
             // Same place as the "Activate now" button.
             <SafeAreaView style={styles.liveButtonSafe}>
               <View style={styles.liveButtonInner}>
-                <GreenButton text="Continue" onPress={handleLiveContinue} />
+                <GreenButton text="Assign it's first task" onPress={handleLiveContinue} />
+              </View>
+            </SafeAreaView>
+          ) : provisionError ? (
+            <SafeAreaView style={styles.liveButtonSafe}>
+              <View style={styles.liveButtonInner}>
+                <Text style={styles.errorText}>{provisionError}</Text>
+                <GreenButton text="Try again" onPress={handleRetry} />
               </View>
             </SafeAreaView>
           ) : (
             <View style={styles.activateBottom}>
-              <Text style={styles.loadingText}>{LOADING_MSGS[loadingStep]}</Text>
+              <View style={styles.loadingRow}>
+                <View style={styles.loadingLeft}>
+                  <DotMatrixLoader
+                    size={20}
+                    dotSize={3}
+                    speed={0.8}
+                    pattern="rings"
+                    colorPreset="solid-theme"
+                    opacityBase={0.12}
+                    opacityMid={0.42}
+                    opacityPeak={1}
+                  />
+                  <ShimmerText text={LOADING_MSGS[loadingStep]} />
+                </View>
+                <View style={styles.simpleDot} />
+              </View>
             </View>
           )}
         </Animated.View>
@@ -353,6 +542,13 @@ const styles = StyleSheet.create({
   backBtn: {
     marginTop: 8,
     marginLeft: 16,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+  },
+  backText: {
+    fontFamily: SFPro.semiBold,
+    fontSize: 17,
+    color: "#3D841E",
   },
   liveTitle: {
     position: "absolute",
@@ -362,7 +558,7 @@ const styles = StyleSheet.create({
     fontFamily: SFPro.bold,
     fontSize: 28,
     color: "#000000",
-    textAlign: "center",
+    textAlign: "left",
     lineHeight: 32,
     letterSpacing: -0.8,
   },
@@ -371,9 +567,26 @@ const styles = StyleSheet.create({
     top: SCREEN_HEIGHT * 0.61,
     left: 24,
     right: 24,
-    alignItems: "center",
+    alignItems: "flex-start",
     minHeight: 52,
     justifyContent: "center",
+  },
+  loadingRow: {
+    width: "100%",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  loadingLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  simpleDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: "#3D841E",
   },
   // Mirrors the naming card's button position (card left/right 16 + content
   // paddingHorizontal 24 + paddingBottom 48 + safe-area inset).
@@ -392,6 +605,14 @@ const styles = StyleSheet.create({
     fontSize: 17,
     color: "#56657D",
     letterSpacing: -0.3,
+  },
+  errorText: {
+    fontFamily: SFPro.medium,
+    fontSize: 15,
+    color: "#841E1E",
+    textAlign: "left",
+    lineHeight: 21,
+    marginBottom: 4,
   },
 
   // ── Button ──

--- a/app/onboarding/vm-ready.tsx
+++ b/app/onboarding/vm-ready.tsx
@@ -253,7 +253,10 @@ export default function VmReadyScreen() {
     return () => {
       cancelled = true;
     };
-  }, [phase, retryCount, name, router]);
+    // `name` and `router` are stable during activation; re-running on their
+    // identity would cancel the pending go-live and loop forever.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, retryCount]);
 
   const handleActivate = async () => {
     const trimmed = name.trim();

--- a/app/onboarding/vm-ready.tsx
+++ b/app/onboarding/vm-ready.tsx
@@ -1,3 +1,4 @@
+import BackButton from "@/assets/images/new-design/chat/back-button.svg";
 import { Confetti } from "@/components/onboarding/Confetti";
 import { ServerTerminal } from "@/components/onboarding/ServerTerminal";
 import { SFPro } from "@/constants/theme";
@@ -8,6 +9,7 @@ import React, { useEffect, useRef, useState } from "react";
 import {
   Animated,
   Dimensions,
+  Easing,
   Keyboard,
   Platform,
   Pressable,
@@ -19,6 +21,10 @@ import {
 } from "react-native";
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
+
+// Server vertical movement (all transform-based so it can animate on the native driver).
+const KB_SHIFT = -SCREEN_HEIGHT * 0.15; // up when the keyboard opens (naming)
+const ACTIVATE_SHIFT = SCREEN_HEIGHT * 0.12; // down to centre when activating
 
 type Phase = "naming" | "activating" | "live";
 
@@ -33,12 +39,21 @@ export default function VmReadyScreen() {
   const router = useRouter();
   const [name, setName] = useState("");
   const [phase, setPhase] = useState<Phase>("naming");
+  const [mood, setMood] = useState<"idle" | "excited" | "waiting">("idle");
   const [loadingStep, setLoadingStep] = useState(0);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
+
   const scale = useRef(new Animated.Value(1)).current;
   const colorAnim = useRef(new Animated.Value(0)).current;
-  const overlayOpacity = useRef(new Animated.Value(0)).current;
+  const activate = useRef(new Animated.Value(0)).current; // 0 = naming, 1 = activating/live
+  const kbShift = useRef(new Animated.Value(0)).current;
+
+  // Single server's vertical offset = keyboard shift + activation shift.
+  const activateShift = activate.interpolate({ inputRange: [0, 1], outputRange: [0, ACTIVATE_SHIFT] });
+  const serverTranslateY = Animated.add(kbShift, activateShift);
+  const namingOpacity = activate.interpolate({ inputRange: [0, 0.55], outputRange: [1, 0], extrapolate: "clamp" });
+  const activateOpacity = activate.interpolate({ inputRange: [0.45, 1], outputRange: [0, 1], extrapolate: "clamp" });
 
   useEffect(() => {
     const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
@@ -46,16 +61,31 @@ export default function VmReadyScreen() {
     const show = Keyboard.addListener(showEvent, (e) => {
       setKeyboardHeight(e.endCoordinates.height);
       setKeyboardVisible(true);
+      Animated.timing(kbShift, { toValue: KB_SHIFT, duration: 260, useNativeDriver: true }).start();
     });
     const hide = Keyboard.addListener(hideEvent, () => {
       setKeyboardHeight(0);
       setKeyboardVisible(false);
+      Animated.timing(kbShift, { toValue: 0, duration: 260, useNativeDriver: true }).start();
     });
     return () => {
       show.remove();
       hide.remove();
     };
-  }, []);
+  }, [kbShift]);
+
+  // Smiley gets excited on activate, then settles into "waiting" (looking down).
+  useEffect(() => {
+    if (phase === "activating" && mood === "excited") {
+      const t = setTimeout(() => setMood("waiting"), 1100);
+      return () => clearTimeout(t);
+    }
+  }, [phase, mood]);
+
+  // Happy again once it's live.
+  useEffect(() => {
+    if (phase === "live") setMood("excited");
+  }, [phase]);
 
   // Loading sequence while "activating", then flip to "live".
   useEffect(() => {
@@ -79,16 +109,28 @@ export default function VmReadyScreen() {
     Keyboard.dismiss();
     await saveVmName(trimmed);
     setPhase("activating");
-    Animated.timing(overlayOpacity, {
+    setMood("excited");
+    Animated.timing(activate, {
       toValue: 1,
-      duration: 420,
+      duration: 600,
+      easing: Easing.inOut(Easing.cubic),
       useNativeDriver: true,
     }).start();
   };
 
+  const handleBack = () => {
+    Animated.timing(activate, {
+      toValue: 0,
+      duration: 420,
+      easing: Easing.inOut(Easing.cubic),
+      useNativeDriver: true,
+    }).start(() => {
+      setPhase("naming");
+      setMood("idle");
+    });
+  };
+
   const handleLiveContinue = () => {
-    // The container is provisioned/verified on vm-final, which then routes
-    // into the dashboard.
     router.replace({ pathname: "/onboarding/vm-final" as any, params: { vmName: name.trim() } });
   };
 
@@ -138,79 +180,84 @@ export default function VmReadyScreen() {
     <>
       <Stack.Screen options={{ headerShown: false }} />
       <View style={styles.container}>
-        {phase === "naming" ? (
-          <>
-            {/* Server + naming card */}
-            <View style={[styles.serverWrap, keyboardVisible && styles.serverWrapKb]}>
-              <ServerTerminal style={styles.server} label={name} />
-            </View>
+        {/* Confetti bursts from behind the (centred) server when live. */}
+        <Confetti visible={phase === "live"} originX={SCREEN_WIDTH / 2} originY={SCREEN_HEIGHT * 0.49} />
 
-            <View
-              style={[
-                styles.gradientOverlay,
-                keyboardVisible && { bottom: keyboardHeight },
-              ]}
-            >
-              <SafeAreaView style={styles.safeContent}>
-                <View style={styles.content}>
-                  <View style={styles.badgeRow}>
-                    <View style={styles.badge}>
-                      <View style={styles.dot} />
-                      <Text style={styles.badgeText}>Your agents computer</Text>
-                    </View>
-                  </View>
+        {/* Single server — animates from the naming spot to screen centre. */}
+        <Animated.View style={[styles.serverWrap, { transform: [{ translateY: serverTranslateY }] }]}>
+          <ServerTerminal style={styles.server} label={name} mood={mood} />
+        </Animated.View>
 
-                  <Text style={styles.title}>Give your Virtual{"\n"}Machine a name.</Text>
-
-                  <TextInput
-                    style={styles.input}
-                    placeholder="e.g. Marvin"
-                    placeholderTextColor="#9AA7BD"
-                    value={name}
-                    onChangeText={setName}
-                    autoCapitalize="words"
-                    autoCorrect={false}
-                    returnKeyType="done"
-                    onSubmitEditing={handleActivate}
-                  />
-
-                  {/* Hidden while typing so it doesn't ride up with the keyboard. */}
-                  {!keyboardVisible && (
-                    <GreenButton text="Activate now" onPress={handleActivate} disabled={!name.trim()} />
-                  )}
-                </View>
-              </SafeAreaView>
-            </View>
-          </>
-        ) : (
-          /* ── Activating / Live ── */
-          <Animated.View style={[StyleSheet.absoluteFill, styles.activateOverlay, { opacity: overlayOpacity }]}>
-            <Confetti
-              visible={phase === "live"}
-              originX={SCREEN_WIDTH / 2}
-              originY={SCREEN_HEIGHT * 0.44}
-            />
-            <SafeAreaView style={styles.activateSafe}>
-              <View style={styles.activateContent}>
-                <Text style={styles.liveTitle}>
-                  {phase === "live" ? `${name} is live!` : "Activating your machine"}
-                </Text>
-
-                <View style={styles.activateServerWrap}>
-                  <ServerTerminal style={styles.server} label={name} />
-                </View>
-
-                <View style={styles.activateBottom}>
-                  {phase === "live" ? (
-                    <GreenButton text="Continue" onPress={handleLiveContinue} />
-                  ) : (
-                    <Text style={styles.loadingText}>{LOADING_MSGS[loadingStep]}</Text>
-                  )}
+        {/* Naming card — fades out as we activate. */}
+        <Animated.View
+          pointerEvents={phase === "naming" ? "auto" : "none"}
+          style={[
+            styles.gradientOverlay,
+            { opacity: namingOpacity },
+            keyboardVisible && { bottom: keyboardHeight },
+          ]}
+        >
+          <SafeAreaView style={styles.safeContent}>
+            <View style={styles.content}>
+              <View style={styles.badgeRow}>
+                <View style={styles.badge}>
+                  <View style={styles.dot} />
+                  <Text style={styles.badgeText}>Your agents computer</Text>
                 </View>
               </View>
+
+              <Text style={styles.title}>Give your Virtual{"\n"}Machine a name.</Text>
+
+              <TextInput
+                style={styles.input}
+                placeholder="e.g. Marvin"
+                placeholderTextColor="#9AA7BD"
+                value={name}
+                onChangeText={setName}
+                autoCapitalize="words"
+                autoCorrect={false}
+                returnKeyType="done"
+                onSubmitEditing={handleActivate}
+              />
+
+              {!keyboardVisible && (
+                <GreenButton text="Activate now" onPress={handleActivate} disabled={!name.trim()} />
+              )}
+            </View>
+          </SafeAreaView>
+        </Animated.View>
+
+        {/* Activation / live content — fades in around the centred server. */}
+        <Animated.View
+          pointerEvents={phase === "naming" ? "none" : "auto"}
+          style={[StyleSheet.absoluteFill, { opacity: activateOpacity }]}
+        >
+          {phase === "live" && (
+            <SafeAreaView style={styles.backSafe}>
+              {/* TEMP back button */}
+              <Pressable style={styles.backBtn} hitSlop={10} onPress={handleBack}>
+                <BackButton />
+              </Pressable>
             </SafeAreaView>
-          </Animated.View>
-        )}
+          )}
+
+          <Text style={styles.liveTitle}>
+            {phase === "live" ? `${name} is live!` : "Activating your machine"}
+          </Text>
+
+          {phase === "live" ? (
+            // Same place as the "Activate now" button.
+            <SafeAreaView style={styles.liveButtonSafe}>
+              <View style={styles.liveButtonInner}>
+                <GreenButton text="Continue" onPress={handleLiveContinue} />
+              </View>
+            </SafeAreaView>
+          ) : (
+            <View style={styles.activateBottom}>
+              <Text style={styles.loadingText}>{LOADING_MSGS[loadingStep]}</Text>
+            </View>
+          )}
+        </Animated.View>
       </View>
     </>
   );
@@ -230,9 +277,6 @@ const styles = StyleSheet.create({
   },
   server: {
     width: "85.5%",
-  },
-  serverWrapKb: {
-    top: SCREEN_HEIGHT * 0.15,
   },
   gradientOverlay: {
     position: "absolute",
@@ -301,37 +345,47 @@ const styles = StyleSheet.create({
   },
 
   // ── Activating / Live ──
-  activateOverlay: {
-    backgroundColor: "#fff",
+  backSafe: {
+    position: "absolute",
+    top: 0,
+    left: 0,
   },
-  activateSafe: {
-    flex: 1,
-  },
-  activateContent: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: 24,
+  backBtn: {
+    marginTop: 8,
+    marginLeft: 16,
   },
   liveTitle: {
+    position: "absolute",
+    top: SCREEN_HEIGHT * 0.32,
+    left: 24,
+    right: 24,
     fontFamily: SFPro.bold,
     fontSize: 28,
     color: "#000000",
     textAlign: "center",
     lineHeight: 32,
     letterSpacing: -0.8,
-    marginBottom: 28,
-  },
-  activateServerWrap: {
-    width: "100%",
-    alignItems: "center",
   },
   activateBottom: {
-    marginTop: 32,
-    width: "100%",
+    position: "absolute",
+    top: SCREEN_HEIGHT * 0.61,
+    left: 24,
+    right: 24,
     alignItems: "center",
     minHeight: 52,
     justifyContent: "center",
+  },
+  // Mirrors the naming card's button position (card left/right 16 + content
+  // paddingHorizontal 24 + paddingBottom 48 + safe-area inset).
+  liveButtonSafe: {
+    position: "absolute",
+    left: 16,
+    right: 16,
+    bottom: 16,
+  },
+  liveButtonInner: {
+    paddingHorizontal: 24,
+    paddingBottom: 48,
   },
   loadingText: {
     fontFamily: SFPro.medium,

--- a/app/onboarding/vm-ready.tsx
+++ b/app/onboarding/vm-ready.tsx
@@ -51,6 +51,9 @@ const LOADING_MSGS = [
 // container is already running and the backend resolves near-instantly.
 const ACTIVATING_MIN_MS = 2600;
 
+// Famous fictional AI / robot names, cycled through the name field placeholder.
+const PLACEHOLDER_NAMES = ["HAL 9000", "JARVIS", "R2-D2", "WALL-E", "Joshua", "Bender"];
+
 // A soft sheen that sweeps across the loading text. On the white background the
 // white band only shows where it overlaps the (darker) glyphs, reading as shimmer.
 function ShimmerText({ text }: { text: string }) {
@@ -93,6 +96,61 @@ function ShimmerText({ text }: { text: string }) {
   );
 }
 
+// One labelled metric cell in the telemetry strip.
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.metric}>
+      <Text style={styles.metricLabel}>{label}</Text>
+      <Text style={styles.metricValue}>{value}</Text>
+    </View>
+  );
+}
+
+// Live VM telemetry shown below the server once it's up — a compact device
+// read-out. The numbers are a lightweight simulation (the backend doesn't
+// stream these yet); the layout mirrors a real status bar.
+function LiveStats() {
+  const [uptime, setUptime] = useState(0); // seconds
+  const [ping, setPing] = useState(12);
+  const [cpu, setCpu] = useState(1);
+  const [ram, setRam] = useState(4);
+
+  useEffect(() => {
+    const up = setInterval(() => setUptime((s) => s + 1), 1000);
+    const net = setInterval(() => setPing(12 + Math.floor(Math.random() * 39)), 1000); // 12–50
+    const sys = setInterval(() => {
+      setCpu(1 + Math.floor(Math.random() * 4)); // 1–4
+      setRam(4 + Math.floor(Math.random() * 3)); // 4–6
+    }, 1500);
+    return () => {
+      clearInterval(up);
+      clearInterval(net);
+      clearInterval(sys);
+    };
+  }, []);
+
+  const fmt = (s: number) => {
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    const sec = s % 60;
+    return [h, m, sec].map((n) => String(n).padStart(2, "0")).join(":");
+  };
+
+  return (
+    <View style={styles.stats}>
+      <View style={styles.telemetryStrip}>
+        <Metric label="UPTIME" value={fmt(uptime)} />
+        <View style={styles.metricDivider} />
+        <Metric label="PING" value={`${ping}ms`} />
+        <View style={styles.metricDivider} />
+        <Metric label="CPU" value={`${cpu}%`} />
+        <View style={styles.metricDivider} />
+        <Metric label="RAM" value={`${ram}%`} />
+      </View>
+    </View>
+  );
+}
+
 export default function VmReadyScreen() {
   const router = useRouter();
   const [name, setName] = useState("");
@@ -104,11 +162,13 @@ export default function VmReadyScreen() {
   const [serverUrl, setServerUrl] = useState<string | undefined>(undefined);
   const [provisionError, setProvisionError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
+  const [placeholderIdx, setPlaceholderIdx] = useState(0);
 
   const scale = useRef(new Animated.Value(1)).current;
   const colorAnim = useRef(new Animated.Value(0)).current;
   const activate = useRef(new Animated.Value(0)).current; // 0 = naming, 1 = activating/live
   const kbShift = useRef(new Animated.Value(0)).current;
+  const placeholderOpacity = useRef(new Animated.Value(1)).current;
 
   // Single server's vertical offset = keyboard shift + activation shift.
   const activateShift = activate.interpolate({ inputRange: [0, 1], outputRange: [0, ACTIVATE_SHIFT] });
@@ -147,6 +207,19 @@ export default function VmReadyScreen() {
   useEffect(() => {
     if (phase === "live") setMood("excited");
   }, [phase]);
+
+  // Cycle the placeholder through famous AI names while naming — dissolve the
+  // old name out, swap, then fade the new one in.
+  useEffect(() => {
+    if (phase !== "naming") return;
+    const id = setInterval(() => {
+      Animated.timing(placeholderOpacity, { toValue: 0, duration: 260, useNativeDriver: true }).start(() => {
+        setPlaceholderIdx((i) => (i + 1) % PLACEHOLDER_NAMES.length);
+        Animated.timing(placeholderOpacity, { toValue: 1, duration: 260, useNativeDriver: true }).start();
+      });
+    }, 2000);
+    return () => clearInterval(id);
+  }, [phase, placeholderOpacity]);
 
   // Cycle the loading messages while "activating".
   useEffect(() => {
@@ -391,17 +464,26 @@ export default function VmReadyScreen() {
 
               <Text style={styles.title}>Give your Virtual{"\n"}Machine a name.</Text>
 
-              <TextInput
-                style={styles.input}
-                placeholder="e.g. Marvin"
-                placeholderTextColor="#9AA7BD"
-                value={name}
-                onChangeText={setName}
-                autoCapitalize="words"
-                autoCorrect={false}
-                returnKeyType="done"
-                onSubmitEditing={handleActivate}
-              />
+              <View style={styles.inputWrap}>
+                <TextInput
+                  style={styles.input}
+                  placeholder=""
+                  value={name}
+                  onChangeText={setName}
+                  autoCapitalize="words"
+                  autoCorrect={false}
+                  returnKeyType="done"
+                  onSubmitEditing={handleActivate}
+                />
+                {name.length === 0 && (
+                  <View style={styles.inputPlaceholder} pointerEvents="none">
+                    <Text style={styles.placeholderPrefix}>e.g. </Text>
+                    <Animated.Text style={[styles.placeholderName, { opacity: placeholderOpacity }]}>
+                      {PLACEHOLDER_NAMES[placeholderIdx]}
+                    </Animated.Text>
+                  </View>
+                )}
+              </View>
 
               {!keyboardVisible && (
                 <GreenButton text="Activate now" onPress={handleActivate} disabled={!name.trim()} />
@@ -432,6 +514,12 @@ export default function VmReadyScreen() {
                 ? "Couldn't start your machine"
                 : "Activating your machine"}
           </Text>
+
+          {phase === "live" && (
+            <View style={styles.statsWrap}>
+              <LiveStats />
+            </View>
+          )}
 
           {phase === "live" ? (
             // Same place as the "Activate now" button.
@@ -541,6 +629,10 @@ const styles = StyleSheet.create({
     letterSpacing: -1,
     marginBottom: 16,
   },
+  inputWrap: {
+    width: "100%",
+    justifyContent: "center",
+  },
   input: {
     width: "100%",
     height: 50,
@@ -552,6 +644,24 @@ const styles = StyleSheet.create({
     fontFamily: SFPro.medium,
     fontSize: 17,
     color: "#16243A",
+  },
+  inputPlaceholder: {
+    position: "absolute",
+    left: 15,
+    top: 0,
+    height: 50,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  placeholderPrefix: {
+    fontFamily: SFPro.medium,
+    fontSize: 17,
+    color: "#9AA7BD",
+  },
+  placeholderName: {
+    fontFamily: SFPro.medium,
+    fontSize: 17,
+    color: "#9AA7BD",
   },
 
   // ── Activating / Live ──
@@ -626,6 +736,55 @@ const styles = StyleSheet.create({
     fontSize: 17,
     color: "#56657D",
     letterSpacing: -0.3,
+  },
+
+  // ── Live telemetry strip ──
+  statsWrap: {
+    position: "absolute",
+    top: SCREEN_HEIGHT * 0.6,
+    left: 24,
+    right: 24,
+    alignItems: "center",
+  },
+  stats: {
+    width: "100%",
+    alignItems: "center",
+    gap: 16,
+  },
+  telemetryStrip: {
+    width: "98%",
+    alignSelf: "center",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-evenly",
+    paddingVertical: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#E7ECF3",
+    backgroundColor: "#FBFCFE",
+  },
+  metric: {
+    alignItems: "center",
+    gap: 4,
+  },
+  metricLabel: {
+    fontFamily: SFPro.semiBold,
+    fontSize: 10,
+    letterSpacing: 1.2,
+    color: "#8090A6",
+  },
+  metricValue: {
+    fontFamily: "Courier New",
+    fontWeight: "700",
+    fontSize: 15,
+    color: "#16243A",
+    letterSpacing: -0.2,
+  },
+  metricDivider: {
+    width: 1,
+    height: 26,
+    alignSelf: "center",
+    backgroundColor: "#E7ECF3",
   },
   errorText: {
     fontFamily: SFPro.medium,

--- a/app/onboarding/vm-ready.tsx
+++ b/app/onboarding/vm-ready.tsx
@@ -168,8 +168,18 @@ export default function VmReadyScreen() {
     let cancelled = false;
     const startedAt = Date.now();
 
+    // Safety net: never let the loader hang silently. If nothing has resolved
+    // after 40s, surface a retry instead of spinning forever.
+    const hangGuard = setTimeout(() => {
+      if (!cancelled) {
+        console.warn("[vm-ready] provisioning timed out after 40s");
+        setProvisionError("This is taking longer than expected.");
+      }
+    }, 40000);
+
     const goLive = async (url?: string) => {
       if (cancelled) return;
+      console.log("[vm-ready] goLive — VM ready, url:", url);
       if (url) await saveVmUrl(url);
       setServerUrl(url);
       notifyGrassVmReady();
@@ -182,11 +192,17 @@ export default function VmReadyScreen() {
 
     async function provision() {
       const token = await getToken();
-      if (!token || cancelled) return;
+      if (cancelled) return;
+      if (!token) {
+        console.warn("[vm-ready] no auth token — cannot provision");
+        setProvisionError("You're not signed in. Please log in and try again.");
+        return;
+      }
 
       // 1. Heartbeat — container may already be running.
       const hb = await heartbeat(token);
       if (cancelled) return;
+      console.log("[vm-ready] heartbeat:", JSON.stringify(hb));
 
       if (!hb.ok && isSandboxUsageLimitError(hb)) {
         notifyGrassSandboxUsageLimitHit();
@@ -235,6 +251,7 @@ export default function VmReadyScreen() {
       // 3. Container stopped / not found — request / restart it.
       const result = await requestContainer(token);
       if (cancelled) return;
+      console.log("[vm-ready] requestContainer:", JSON.stringify(result));
 
       if (result.ok) {
         posthog.capture("container_provisioned");
@@ -252,6 +269,7 @@ export default function VmReadyScreen() {
     provision();
     return () => {
       cancelled = true;
+      clearTimeout(hangGuard);
     };
     // `name` and `router` are stable during activation; re-running on their
     // identity would cancel the pending go-live and loop forever.

--- a/app/onboarding/vm-ready.tsx
+++ b/app/onboarding/vm-ready.tsx
@@ -1,24 +1,96 @@
+import { Confetti } from "@/components/onboarding/Confetti";
+import { ServerTerminal } from "@/components/onboarding/ServerTerminal";
 import { SFPro } from "@/constants/theme";
-import { Image } from "expo-image";
+import { setVmName as saveVmName } from "@/store/vm-metadata-store";
 import { LinearGradient } from "expo-linear-gradient";
 import { Stack, useRouter } from "expo-router";
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Animated,
   Dimensions,
+  Keyboard,
+  Platform,
   Pressable,
   SafeAreaView,
   StyleSheet,
   Text,
+  TextInput,
   View,
 } from "react-native";
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
 
+type Phase = "naming" | "activating" | "live";
+
+const LOADING_MSGS = [
+  "Spinning up your machine…",
+  "Allocating compute…",
+  "Booting things up…",
+  "Almost there…",
+];
+
 export default function VmReadyScreen() {
   const router = useRouter();
+  const [name, setName] = useState("");
+  const [phase, setPhase] = useState<Phase>("naming");
+  const [loadingStep, setLoadingStep] = useState(0);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
   const scale = useRef(new Animated.Value(1)).current;
   const colorAnim = useRef(new Animated.Value(0)).current;
+  const overlayOpacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+    const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+    const show = Keyboard.addListener(showEvent, (e) => {
+      setKeyboardHeight(e.endCoordinates.height);
+      setKeyboardVisible(true);
+    });
+    const hide = Keyboard.addListener(hideEvent, () => {
+      setKeyboardHeight(0);
+      setKeyboardVisible(false);
+    });
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
+
+  // Loading sequence while "activating", then flip to "live".
+  useEffect(() => {
+    if (phase !== "activating") return;
+    setLoadingStep(0);
+    let step = 0;
+    const interval = setInterval(() => {
+      step += 1;
+      setLoadingStep(step % LOADING_MSGS.length);
+    }, 850);
+    const done = setTimeout(() => setPhase("live"), 3200);
+    return () => {
+      clearInterval(interval);
+      clearTimeout(done);
+    };
+  }, [phase]);
+
+  const handleActivate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    Keyboard.dismiss();
+    await saveVmName(trimmed);
+    setPhase("activating");
+    Animated.timing(overlayOpacity, {
+      toValue: 1,
+      duration: 420,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const handleLiveContinue = () => {
+    // The container is provisioned/verified on vm-final, which then routes
+    // into the dashboard.
+    router.replace({ pathname: "/onboarding/vm-final" as any, params: { vmName: name.trim() } });
+  };
 
   const backgroundColor = colorAnim.interpolate({
     inputRange: [0, 1],
@@ -39,63 +111,106 @@ export default function VmReadyScreen() {
     ]).start();
   };
 
+  const GreenButton = ({ text, onPress, disabled }: { text: string; onPress: () => void; disabled?: boolean }) => (
+    <Pressable
+      style={[styles.pressable, disabled && styles.pressableDisabled]}
+      onPressIn={onPressIn}
+      onPressOut={onPressOut}
+      disabled={disabled}
+      onPress={onPress}
+    >
+      <Animated.View style={[styles.buttonShadowWrap, { transform: [{ scale }] }]}>
+        <LinearGradient
+          colors={["#7ED957", "#1A4D09"]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 0, y: 1 }}
+          style={styles.buttonBorder}
+        >
+          <Animated.View style={[styles.button, { backgroundColor }]}>
+            <Text style={styles.buttonText}>{text}</Text>
+          </Animated.View>
+        </LinearGradient>
+      </Animated.View>
+    </Pressable>
+  );
+
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
       <View style={styles.container}>
-        {/* Full-screen illustration */}
-        <Image
-          source={require("@/assets/images/new-design/onboarding/vm-illustration.png")}
-          style={styles.illustration}
-          contentFit="contain"
-        />
+        {phase === "naming" ? (
+          <>
+            {/* Server + naming card */}
+            <View style={[styles.serverWrap, keyboardVisible && styles.serverWrapKb]}>
+              <ServerTerminal style={styles.server} label={name} />
+            </View>
 
-        {/* Gradient + content overlaid at the bottom of the image */}
-        <LinearGradient
-          colors={["#ffffff30", "#ffffff30"]}
-          locations={[0, 0.45]}
-          style={styles.gradientOverlay}
-        >
-          <SafeAreaView style={styles.safeContent}>
-            <View style={styles.content}>
-              {/* Ready to provision badge */}
-              <View style={styles.badgeRow}>
-                <View style={styles.badge}>
-                  <View style={styles.dot} />
-                  <Text style={styles.badgeText}>Ready to provision</Text>
+            <View
+              style={[
+                styles.gradientOverlay,
+                keyboardVisible && { bottom: keyboardHeight },
+              ]}
+            >
+              <SafeAreaView style={styles.safeContent}>
+                <View style={styles.content}>
+                  <View style={styles.badgeRow}>
+                    <View style={styles.badge}>
+                      <View style={styles.dot} />
+                      <Text style={styles.badgeText}>Your agents computer</Text>
+                    </View>
+                  </View>
+
+                  <Text style={styles.title}>Give your Virtual{"\n"}Machine a name.</Text>
+
+                  <TextInput
+                    style={styles.input}
+                    placeholder="e.g. Marvin"
+                    placeholderTextColor="#9AA7BD"
+                    value={name}
+                    onChangeText={setName}
+                    autoCapitalize="words"
+                    autoCorrect={false}
+                    returnKeyType="done"
+                    onSubmitEditing={handleActivate}
+                  />
+
+                  {/* Hidden while typing so it doesn't ride up with the keyboard. */}
+                  {!keyboardVisible && (
+                    <GreenButton text="Activate now" onPress={handleActivate} disabled={!name.trim()} />
+                  )}
+                </View>
+              </SafeAreaView>
+            </View>
+          </>
+        ) : (
+          /* ── Activating / Live ── */
+          <Animated.View style={[StyleSheet.absoluteFill, styles.activateOverlay, { opacity: overlayOpacity }]}>
+            <Confetti
+              visible={phase === "live"}
+              originX={SCREEN_WIDTH / 2}
+              originY={SCREEN_HEIGHT * 0.44}
+            />
+            <SafeAreaView style={styles.activateSafe}>
+              <View style={styles.activateContent}>
+                <Text style={styles.liveTitle}>
+                  {phase === "live" ? `${name} is live!` : "Activating your machine"}
+                </Text>
+
+                <View style={styles.activateServerWrap}>
+                  <ServerTerminal style={styles.server} label={name} />
+                </View>
+
+                <View style={styles.activateBottom}>
+                  {phase === "live" ? (
+                    <GreenButton text="Continue" onPress={handleLiveContinue} />
+                  ) : (
+                    <Text style={styles.loadingText}>{LOADING_MSGS[loadingStep]}</Text>
+                  )}
                 </View>
               </View>
-
-              <Text style={styles.title}>Meet your new{"\n"}computer.</Text>
-              <Text style={styles.subtitle}>
-                Your dedicated VM is ready.{"\n"}Always available, waiting for
-                your
-                {"\n"}first message.
-              </Text>
-
-              {/* Give them a name button */}
-              <Pressable
-                style={styles.pressable}
-                onPressIn={onPressIn}
-                onPressOut={onPressOut}
-                onPress={() => router.push("/onboarding/vm-name" as any)}
-              >
-                <Animated.View style={[styles.buttonShadowWrap, { transform: [{ scale }] }]}>
-                  <LinearGradient
-                    colors={["#7ED957", "#1A4D09"]}
-                    start={{ x: 0, y: 0 }}
-                    end={{ x: 0, y: 1 }}
-                    style={styles.buttonBorder}
-                  >
-                    <Animated.View style={[styles.button, { backgroundColor }]}>
-                      <Text style={styles.buttonText}>Give them a name</Text>
-                    </Animated.View>
-                  </LinearGradient>
-                </Animated.View>
-              </Pressable>
-            </View>
-          </SafeAreaView>
-        </LinearGradient>
+            </SafeAreaView>
+          </Animated.View>
+        )}
       </View>
     </>
   );
@@ -106,12 +221,18 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#fff",
   },
-  illustration: {
+  serverWrap: {
     position: "absolute",
-    left: SCREEN_WIDTH * 0,
-    right: SCREEN_WIDTH * 0,
-    height: SCREEN_HEIGHT * 1.3,
-    bottom: 0,
+    left: 0,
+    right: 0,
+    top: SCREEN_HEIGHT * 0.3,
+    alignItems: "center",
+  },
+  server: {
+    width: "85.5%",
+  },
+  serverWrapKb: {
+    top: SCREEN_HEIGHT * 0.15,
   },
   gradientOverlay: {
     position: "absolute",
@@ -129,7 +250,7 @@ const styles = StyleSheet.create({
   content: {
     paddingHorizontal: 24,
     paddingBottom: 48,
-    alignItems: "center",
+    alignItems: "flex-start",
   },
   badgeRow: {
     marginBottom: 16,
@@ -161,22 +282,71 @@ const styles = StyleSheet.create({
     fontFamily: SFPro.bold,
     fontSize: 28,
     color: "#000000",
-    textAlign: "center",
+    textAlign: "left",
     lineHeight: 32,
     letterSpacing: -1,
-    marginBottom: 12,
+    marginBottom: 16,
   },
-  subtitle: {
-    fontFamily: SFPro.regular,
+  input: {
+    width: "100%",
+    height: 50,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#D5DEEA",
+    backgroundColor: "#FFFFFF",
+    paddingHorizontal: 14,
+    fontFamily: SFPro.medium,
     fontSize: 17,
-    color: "#000",
-    textAlign: "center",
-    lineHeight: 22,
-    letterSpacing: -0.5,
+    color: "#16243A",
   },
+
+  // ── Activating / Live ──
+  activateOverlay: {
+    backgroundColor: "#fff",
+  },
+  activateSafe: {
+    flex: 1,
+  },
+  activateContent: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  liveTitle: {
+    fontFamily: SFPro.bold,
+    fontSize: 28,
+    color: "#000000",
+    textAlign: "center",
+    lineHeight: 32,
+    letterSpacing: -0.8,
+    marginBottom: 28,
+  },
+  activateServerWrap: {
+    width: "100%",
+    alignItems: "center",
+  },
+  activateBottom: {
+    marginTop: 32,
+    width: "100%",
+    alignItems: "center",
+    minHeight: 52,
+    justifyContent: "center",
+  },
+  loadingText: {
+    fontFamily: SFPro.medium,
+    fontSize: 17,
+    color: "#56657D",
+    letterSpacing: -0.3,
+  },
+
+  // ── Button ──
   pressable: {
     marginTop: 24,
     width: "100%",
+  },
+  pressableDisabled: {
+    opacity: 0.45,
   },
   buttonShadowWrap: {
     width: "100%",

--- a/components/onboarding/Confetti.tsx
+++ b/components/onboarding/Confetti.tsx
@@ -3,14 +3,14 @@ import { Animated, Dimensions, Easing, StyleSheet, View } from "react-native";
 
 const { width: W, height: H } = Dimensions.get("window");
 const COLORS = ["#4FA825", "#7ED957", "#3A7D1C", "#5CC330", "#2E6B10", "#8FE85A", "#6DD148", "#A8E87A"];
-const COUNT = 70;
+const COUNT = 80;
 
 type Piece = {
   size: number;
   color: string;
-  launchY: number;
-  spreadX: number;
-  launchDur: number;
+  startX: number; // horizontal spawn across the screen
+  startY: number; // spawn above the top edge (negative)
+  swayX: number; // horizontal flutter while falling
   fallDur: number;
   delay: number;
   rotateTo: number;
@@ -21,27 +21,21 @@ type Piece = {
 };
 
 /**
- * A celebratory confetti burst that erupts upward/outward from (originX, originY)
- * — e.g. from behind the server — then rains down. Plays once when `visible` flips true.
+ * A celebratory confetti shower that rains down from above the top of the
+ * screen, fluttering and rotating as it falls, then fades near the bottom.
+ * Rendered at a high z-index so it sits above all content. Plays once when
+ * `visible` flips true.
  */
-export function Confetti({
-  visible,
-  originX = W / 2,
-  originY = H / 2,
-}: {
-  visible: boolean;
-  originX?: number;
-  originY?: number;
-}) {
+export function Confetti({ visible }: { visible: boolean; originX?: number; originY?: number }) {
   const pieces = useRef<Piece[]>(
     Array.from({ length: COUNT }, () => ({
       size: 6 + Math.random() * 7,
       color: COLORS[Math.floor(Math.random() * COLORS.length)],
-      launchY: -(120 + Math.random() * 240),
-      spreadX: (Math.random() * 2 - 1) * (40 + Math.random() * 150),
-      launchDur: 420 + Math.random() * 320,
-      fallDur: 1500 + Math.random() * 1100,
-      delay: Math.random() * 220,
+      startX: Math.random() * W,
+      startY: -(20 + Math.random() * 160), // above the screen
+      swayX: (Math.random() * 2 - 1) * (30 + Math.random() * 70),
+      fallDur: 2200 + Math.random() * 1600,
+      delay: Math.random() * 500,
       rotateTo: (Math.random() > 0.5 ? 1 : -1) * (2 + Math.floor(Math.random() * 4)) * 180,
       ty: new Animated.Value(0),
       tx: new Animated.Value(0),
@@ -57,30 +51,37 @@ export function Confetti({
       p.tx.setValue(0);
       p.rot.setValue(0);
       p.op.setValue(1);
-      const total = p.launchDur + p.fallDur;
       Animated.sequence([
         Animated.delay(p.delay),
         Animated.parallel([
-          // up then down
+          // Fall from above the top edge down past the bottom.
+          Animated.timing(p.ty, {
+            toValue: H - p.startY + 60,
+            duration: p.fallDur,
+            easing: Easing.in(Easing.quad),
+            useNativeDriver: true,
+          }),
+          // Gentle horizontal flutter.
+          Animated.timing(p.tx, {
+            toValue: p.swayX,
+            duration: p.fallDur,
+            easing: Easing.inOut(Easing.sin),
+            useNativeDriver: true,
+          }),
+          Animated.timing(p.rot, { toValue: 1, duration: p.fallDur, easing: Easing.linear, useNativeDriver: true }),
           Animated.sequence([
-            Animated.timing(p.ty, { toValue: p.launchY, duration: p.launchDur, easing: Easing.out(Easing.quad), useNativeDriver: true }),
-            Animated.timing(p.ty, { toValue: H - originY + 40, duration: p.fallDur, easing: Easing.in(Easing.quad), useNativeDriver: true }),
-          ]),
-          Animated.timing(p.tx, { toValue: p.spreadX, duration: total, easing: Easing.out(Easing.quad), useNativeDriver: true }),
-          Animated.timing(p.rot, { toValue: 1, duration: total, easing: Easing.linear, useNativeDriver: true }),
-          Animated.sequence([
-            Animated.delay(total * 0.65),
-            Animated.timing(p.op, { toValue: 0, duration: total * 0.35, useNativeDriver: true }),
+            Animated.delay(p.fallDur * 0.7),
+            Animated.timing(p.op, { toValue: 0, duration: p.fallDur * 0.3, useNativeDriver: true }),
           ]),
         ]),
       ]).start();
     });
-  }, [visible, pieces, originY]);
+  }, [visible, pieces]);
 
   if (!visible) return null;
 
   return (
-    <View style={StyleSheet.absoluteFill} pointerEvents="none">
+    <View style={styles.layer} pointerEvents="none">
       {pieces.map((p, i) => {
         const rotate = p.rot.interpolate({ inputRange: [0, 1], outputRange: ["0deg", `${p.rotateTo}deg`] });
         return (
@@ -88,8 +89,8 @@ export function Confetti({
             key={i}
             style={{
               position: "absolute",
-              left: originX,
-              top: originY,
+              left: p.startX,
+              top: p.startY,
               width: p.size,
               height: p.size * 0.6,
               borderRadius: 1.5,
@@ -103,3 +104,11 @@ export function Confetti({
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  layer: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 9999,
+    elevation: 9999,
+  },
+});

--- a/components/onboarding/Confetti.tsx
+++ b/components/onboarding/Confetti.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useRef } from "react";
+import { Animated, Dimensions, Easing, StyleSheet, View } from "react-native";
+
+const { width: W, height: H } = Dimensions.get("window");
+const COLORS = ["#4FA825", "#7ED957", "#3A7D1C", "#5CC330", "#2E6B10", "#8FE85A", "#6DD148", "#A8E87A"];
+const COUNT = 70;
+
+type Piece = {
+  size: number;
+  color: string;
+  launchY: number;
+  spreadX: number;
+  launchDur: number;
+  fallDur: number;
+  delay: number;
+  rotateTo: number;
+  ty: Animated.Value;
+  tx: Animated.Value;
+  rot: Animated.Value;
+  op: Animated.Value;
+};
+
+/**
+ * A celebratory confetti burst that erupts upward/outward from (originX, originY)
+ * — e.g. from behind the server — then rains down. Plays once when `visible` flips true.
+ */
+export function Confetti({
+  visible,
+  originX = W / 2,
+  originY = H / 2,
+}: {
+  visible: boolean;
+  originX?: number;
+  originY?: number;
+}) {
+  const pieces = useRef<Piece[]>(
+    Array.from({ length: COUNT }, () => ({
+      size: 6 + Math.random() * 7,
+      color: COLORS[Math.floor(Math.random() * COLORS.length)],
+      launchY: -(120 + Math.random() * 240),
+      spreadX: (Math.random() * 2 - 1) * (40 + Math.random() * 150),
+      launchDur: 420 + Math.random() * 320,
+      fallDur: 1500 + Math.random() * 1100,
+      delay: Math.random() * 220,
+      rotateTo: (Math.random() > 0.5 ? 1 : -1) * (2 + Math.floor(Math.random() * 4)) * 180,
+      ty: new Animated.Value(0),
+      tx: new Animated.Value(0),
+      rot: new Animated.Value(0),
+      op: new Animated.Value(0),
+    })),
+  ).current;
+
+  useEffect(() => {
+    if (!visible) return;
+    pieces.forEach((p) => {
+      p.ty.setValue(0);
+      p.tx.setValue(0);
+      p.rot.setValue(0);
+      p.op.setValue(1);
+      const total = p.launchDur + p.fallDur;
+      Animated.sequence([
+        Animated.delay(p.delay),
+        Animated.parallel([
+          // up then down
+          Animated.sequence([
+            Animated.timing(p.ty, { toValue: p.launchY, duration: p.launchDur, easing: Easing.out(Easing.quad), useNativeDriver: true }),
+            Animated.timing(p.ty, { toValue: H - originY + 40, duration: p.fallDur, easing: Easing.in(Easing.quad), useNativeDriver: true }),
+          ]),
+          Animated.timing(p.tx, { toValue: p.spreadX, duration: total, easing: Easing.out(Easing.quad), useNativeDriver: true }),
+          Animated.timing(p.rot, { toValue: 1, duration: total, easing: Easing.linear, useNativeDriver: true }),
+          Animated.sequence([
+            Animated.delay(total * 0.65),
+            Animated.timing(p.op, { toValue: 0, duration: total * 0.35, useNativeDriver: true }),
+          ]),
+        ]),
+      ]).start();
+    });
+  }, [visible, pieces, originY]);
+
+  if (!visible) return null;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none">
+      {pieces.map((p, i) => {
+        const rotate = p.rot.interpolate({ inputRange: [0, 1], outputRange: ["0deg", `${p.rotateTo}deg`] });
+        return (
+          <Animated.View
+            key={i}
+            style={{
+              position: "absolute",
+              left: originX,
+              top: originY,
+              width: p.size,
+              height: p.size * 0.6,
+              borderRadius: 1.5,
+              backgroundColor: p.color,
+              opacity: p.op,
+              transform: [{ translateX: p.tx }, { translateY: p.ty }, { rotate }],
+            }}
+          />
+        );
+      })}
+    </View>
+  );
+}

--- a/components/onboarding/DotMatrixLoader.tsx
+++ b/components/onboarding/DotMatrixLoader.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useRef } from "react";
+import { Animated, StyleSheet, View } from "react-native";
+
+type Pattern = "full" | "rings";
+type ColorPreset = "solid-theme";
+
+const N = 5;
+const CENTER = 2;
+
+const PRESET_COLORS: Record<ColorPreset, string> = {
+  "solid-theme": "#3D841E", // grass theme green
+};
+
+/**
+ * RN port of the Dot Matrix "dotm-square-11" loader ("Echo Ring").
+ *
+ * A 5×5 grid of circular dots. Each active dot pulses through a base → peak →
+ * mid envelope with a soft secondary "echo" pulse, staggered outward by ring
+ * (Manhattan distance from the centre) so concentric diamonds ripple out.
+ *
+ * `pattern="rings"` lights only the cells whose Euclidean radius rounds to 1 or
+ * 2 (everything except the centre and the four corners).
+ */
+export function DotMatrixLoader({
+  size = 36,
+  dotSize = 5,
+  speed = 1,
+  pattern = "full",
+  color = "#3D841E",
+  colorPreset,
+  opacityBase = 0.16,
+  opacityMid = 0.5,
+  opacityPeak = 1,
+}: {
+  size?: number;
+  dotSize?: number;
+  speed?: number;
+  pattern?: Pattern;
+  color?: string;
+  colorPreset?: ColorPreset;
+  opacityBase?: number;
+  opacityMid?: number;
+  opacityPeak?: number;
+}) {
+  const dotColor = colorPreset ? PRESET_COLORS[colorPreset] : color;
+  const gap = (size - N * dotSize) / (N - 1);
+
+  const isActive = (r: number, c: number) => {
+    if (pattern === "full") return true;
+    const radius = Math.hypot(r - CENTER, c - CENTER);
+    const rounded = Math.round(radius);
+    return rounded === 1 || rounded === 2;
+  };
+
+  const values = useRef(
+    Array.from({ length: N * N }, () => new Animated.Value(opacityBase)),
+  ).current;
+
+  useEffect(() => {
+    const s = speed > 0 ? speed : 1;
+    const cycle = 1500 / s; // full echo-ring cycle
+    const started: { loop: Animated.CompositeAnimation; t: ReturnType<typeof setTimeout> }[] = [];
+
+    for (let i = 0; i < N * N; i++) {
+      const r = Math.floor(i / N);
+      const c = i % N;
+      if (!isActive(r, c)) continue;
+
+      const v = values[i];
+      const ring = Math.min(4, Math.abs(r - CENTER) + Math.abs(c - CENTER));
+      const parity = ring % 2;
+      const delay = (ring * 0.14 + parity * 0.03) * cycle;
+
+      const step = (toValue: number, frac: number) =>
+        Animated.timing(v, { toValue, duration: cycle * frac, useNativeDriver: true });
+
+      // Main pulse + soft secondary echo, then rest at base.
+      const loop = Animated.loop(
+        Animated.sequence([
+          step(opacityPeak, 0.16),
+          step(opacityMid, 0.12),
+          step(opacityBase, 0.16),
+          step(opacityBase, 0.1),
+          step(opacityMid, 0.1), // echo
+          step(opacityBase, 0.12),
+          step(opacityBase, 0.24), // hold
+        ]),
+      );
+      const t = setTimeout(() => loop.start(), delay);
+      started.push({ loop, t });
+    }
+
+    return () => started.forEach(({ loop, t }) => { clearTimeout(t); loop.stop(); });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [speed, pattern, opacityBase, opacityMid, opacityPeak]);
+
+  return (
+    <View style={{ width: size, height: size }}>
+      {Array.from({ length: N }).map((_, r) => (
+        <View key={r} style={[styles.row, { marginBottom: r < N - 1 ? gap : 0 }]}>
+          {Array.from({ length: N }).map((_, c) => {
+            const i = r * N + c;
+            const active = isActive(r, c);
+            return (
+              <Animated.View
+                key={c}
+                style={{
+                  width: dotSize,
+                  height: dotSize,
+                  borderRadius: dotSize / 2,
+                  marginRight: c < N - 1 ? gap : 0,
+                  backgroundColor: dotColor,
+                  opacity: active ? values[i] : 0,
+                }}
+              />
+            );
+          })}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+  },
+});

--- a/components/onboarding/ServerTerminal.tsx
+++ b/components/onboarding/ServerTerminal.tsx
@@ -1,0 +1,257 @@
+import { Image } from "expo-image";
+import React, { useEffect, useRef, useState } from "react";
+import { Animated, Easing, StyleProp, StyleSheet, Text, View, ViewStyle } from "react-native";
+import Svg, { Circle, Defs, RadialGradient, Stop } from "react-native-svg";
+
+const GREEN = "#4FA825";
+const LED_COLOR = "#36D95B";
+const GLOW = 14; // diameter of the LED glow halo (display px)
+
+// Power / status LED centres as a % of the server image.
+const LED_POSITIONS = {
+  power: { left: 17.1, top: 25.3 },
+  status: { left: 17.25, top: 44 },
+};
+
+/** Blinking green server LED with a soft radial glow. */
+function Led({ left, top, gid }: { left: number; top: number; gid: string }) {
+  const o = useRef(new Animated.Value(1)).current;
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const blink = () => {
+      if (cancelled) return;
+      const bright = Math.random() > 0.5;
+      const toValue = bright ? 1 : 0.12 + Math.random() * 0.28;
+      const duration = 130 + Math.random() * 170;
+      Animated.timing(o, { toValue, duration, easing: Easing.inOut(Easing.ease), useNativeDriver: true }).start(
+        ({ finished }) => {
+          if (cancelled || !finished) return;
+          const hold = bright ? 70 + Math.random() * 360 : 50 + Math.random() * 170;
+          timer = setTimeout(blink, hold);
+        },
+      );
+    };
+    timer = setTimeout(blink, Math.random() * 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      o.stopAnimation();
+    };
+  }, [o]);
+
+  const id = `srvled-${gid}`;
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[
+        styles.led,
+        { left: `${left}%`, top: `${top}%`, marginLeft: -GLOW / 2, marginTop: -GLOW / 2, opacity: o },
+      ]}
+    >
+      <Svg width={GLOW} height={GLOW}>
+        <Defs>
+          <RadialGradient id={id} cx="50%" cy="50%" r="50%">
+            <Stop offset="0" stopColor="#EAFFEF" stopOpacity={1} />
+            <Stop offset="0.2" stopColor={LED_COLOR} stopOpacity={0.95} />
+            <Stop offset="0.55" stopColor={LED_COLOR} stopOpacity={0.35} />
+            <Stop offset="1" stopColor={LED_COLOR} stopOpacity={0} />
+          </RadialGradient>
+        </Defs>
+        <Circle cx={GLOW / 2} cy={GLOW / 2} r={GLOW / 2} fill={`url(#${id})`} />
+      </Svg>
+    </Animated.View>
+  );
+}
+
+/** A little green face on the monitor: blinks and glances around now and then. */
+function SmileyFace() {
+  const blink = useRef(new Animated.Value(1)).current; // eye scaleY (1 = open)
+  const lookX = useRef(new Animated.Value(0)).current;
+  const lookY = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    let cancelled = false;
+    let blinkTimer: ReturnType<typeof setTimeout>;
+    let lookTimer: ReturnType<typeof setTimeout>;
+
+    const doBlink = () => {
+      if (cancelled) return;
+      const seq: Animated.CompositeAnimation[] = [
+        Animated.timing(blink, { toValue: 0.1, duration: 80, useNativeDriver: true }),
+        Animated.timing(blink, { toValue: 1, duration: 90, useNativeDriver: true }),
+      ];
+      // occasional double blink
+      if (Math.random() < 0.35) {
+        seq.push(
+          Animated.delay(90),
+          Animated.timing(blink, { toValue: 0.1, duration: 80, useNativeDriver: true }),
+          Animated.timing(blink, { toValue: 1, duration: 90, useNativeDriver: true }),
+        );
+      }
+      Animated.sequence(seq).start(() => {
+        if (cancelled) return;
+        blinkTimer = setTimeout(doBlink, 1500 + Math.random() * 2800);
+      });
+    };
+
+    const doLook = () => {
+      if (cancelled) return;
+      const tx = (Math.random() * 2 - 1) * 3; // -3..3 px
+      const ty = (Math.random() * 2 - 1) * 1.2;
+      Animated.parallel([
+        Animated.timing(lookX, { toValue: tx, duration: 300, easing: Easing.out(Easing.ease), useNativeDriver: true }),
+        Animated.timing(lookY, { toValue: ty, duration: 300, easing: Easing.out(Easing.ease), useNativeDriver: true }),
+      ]).start(() => {
+        if (cancelled) return;
+        // hold the glance, then look back to centre
+        lookTimer = setTimeout(() => {
+          if (cancelled) return;
+          Animated.parallel([
+            Animated.timing(lookX, { toValue: 0, duration: 300, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
+            Animated.timing(lookY, { toValue: 0, duration: 300, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
+          ]).start(() => {
+            if (cancelled) return;
+            lookTimer = setTimeout(doLook, 2200 + Math.random() * 3000);
+          });
+        }, 650 + Math.random() * 900);
+      });
+    };
+
+    blinkTimer = setTimeout(doBlink, 1200 + Math.random() * 1500);
+    lookTimer = setTimeout(doLook, 1800 + Math.random() * 1500);
+    return () => {
+      cancelled = true;
+      clearTimeout(blinkTimer);
+      clearTimeout(lookTimer);
+      blink.stopAnimation();
+      lookX.stopAnimation();
+      lookY.stopAnimation();
+    };
+  }, [blink, lookX, lookY]);
+
+  return (
+    <View style={styles.face}>
+      <Animated.View style={[styles.eyes, { transform: [{ translateX: lookX }, { translateY: lookY }] }]}>
+        <Animated.View style={[styles.eye, { transform: [{ scaleY: blink }] }]} />
+        <Animated.View style={[styles.eye, { transform: [{ scaleY: blink }] }]} />
+      </Animated.View>
+      <View style={styles.mouth} />
+    </View>
+  );
+}
+
+// Roughly how many characters fit on the tiny monitor at this font size.
+const PANEL_MAX_CHARS = 10;
+
+/** Mirrors the live typed text on the monitor, with a blinking cursor.
+    Shows the most recent characters — older ones scroll off the left. */
+function TerminalText({ text }: { text: string }) {
+  const [cursor, setCursor] = useState(true);
+  useEffect(() => {
+    const id = setInterval(() => setCursor((v) => !v), 500);
+    return () => clearInterval(id);
+  }, []);
+  const shown = text.length > PANEL_MAX_CHARS ? text.slice(-PANEL_MAX_CHARS) : text;
+  return (
+    <Text style={styles.panelText} numberOfLines={1}>
+      {shown}
+      {cursor ? "▋" : ""}
+    </Text>
+  );
+}
+
+/**
+ * The server illustration with its little monitor. The panel shows the live
+ * typed `label` (with a cursor) while typing, otherwise an animated green
+ * smiley that blinks and looks around. Self-contained — drop it anywhere.
+ */
+export function ServerTerminal({
+  style,
+  label,
+}: {
+  style?: StyleProp<ViewStyle>;
+  label?: string;
+}) {
+  const hasText = (label ?? "").trim().length > 0;
+  return (
+    <View style={[styles.imageContainer, style]}>
+      <Image
+        source={require("@/assets/images/new-design/onboarding/server.png")}
+        style={styles.heroImage}
+        contentFit="contain"
+      />
+      <View style={styles.screenRect}>
+        {hasText ? <TerminalText text={label ?? ""} /> : <SmileyFace />}
+      </View>
+      <Led left={LED_POSITIONS.power.left} top={LED_POSITIONS.power.top} gid="power" />
+      <Led left={LED_POSITIONS.status.left} top={LED_POSITIONS.status.top} gid="status" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  imageContainer: {
+    width: "95%",
+    aspectRatio: 1499 / 521,
+    alignSelf: "center",
+  },
+  heroImage: {
+    width: "100%",
+    height: "100%",
+  },
+  screenRect: {
+    position: "absolute",
+    top: "23%",
+    left: "25.5%",
+    width: "22.3%",
+    height: "30%",
+    backgroundColor: "#000",
+    borderRadius: 3,
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+  },
+  led: {
+    position: "absolute",
+    width: GLOW,
+    height: GLOW,
+  },
+  panelText: {
+    fontFamily: "Courier New",
+    fontSize: 10,
+    lineHeight: 12,
+    fontWeight: "700",
+    color: "#7ED957",
+    textAlign: "center",
+    paddingHorizontal: 2,
+  },
+  face: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  eyes: {
+    flexDirection: "row",
+    gap: 7,
+    marginBottom: 3,
+  },
+  eye: {
+    // Big, round eyes read cuter.
+    width: 6,
+    height: 7,
+    borderRadius: 3.5,
+    backgroundColor: GREEN,
+  },
+  mouth: {
+    // Small, gentle smile under the big eyes.
+    width: 10,
+    height: 6,
+    borderColor: GREEN,
+    borderBottomWidth: 2,
+    borderLeftWidth: 2,
+    borderRightWidth: 2,
+    borderBottomLeftRadius: 9,
+    borderBottomRightRadius: 9,
+    backgroundColor: "transparent",
+  },
+});

--- a/components/onboarding/ServerTerminal.tsx
+++ b/components/onboarding/ServerTerminal.tsx
@@ -76,11 +76,21 @@ function SmileyFace({ mood = "idle" }: { mood?: Mood }) {
   const lookY = useRef(new Animated.Value(0)).current;
   const bounceY = useRef(new Animated.Value(0)).current;
   const scaleA = useRef(new Animated.Value(1)).current;
+  const flat = useRef(new Animated.Value(0)).current; // 0 = smile, 1 = straight line
 
   useEffect(() => {
     let cancelled = false;
     const timers: ReturnType<typeof setTimeout>[] = [];
     const loops: Animated.CompositeAnimation[] = [];
+
+    // Keep eyes open when entering a mood.
+    blink.setValue(1);
+    // Flatten the mouth to a straight line while looking down (waiting), smile otherwise.
+    Animated.timing(flat, {
+      toValue: mood === "waiting" ? 1 : 0,
+      duration: 260,
+      useNativeDriver: true,
+    }).start();
 
     const quickBlink = (cb?: () => void) => {
       Animated.sequence([
@@ -159,29 +169,55 @@ function SmileyFace({ mood = "idle" }: { mood?: Mood }) {
       };
       timers.push(setTimeout(doBlink, 200));
     } else {
-      // waiting — look down at the loading text and blink slowly
+      // waiting — look down at the loading text, eyes scanning like it's reading.
+      // If the load drags on past ~3s it gets bored and yawns now and then.
       Animated.parallel([
-        Animated.timing(lookX, { toValue: 0, duration: 250, useNativeDriver: true }),
         Animated.timing(lookY, { toValue: 3, duration: 380, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
         Animated.timing(bounceY, { toValue: 1, duration: 300, useNativeDriver: true }),
         Animated.timing(scaleA, { toValue: 1, duration: 200, useNativeDriver: true }),
       ]).start();
+
+      // Reading: scan the eyes left→right, then flick back to the line start.
+      const scan = () => {
+        if (cancelled) return;
+        lookX.setValue(-2.2);
+        Animated.sequence([
+          Animated.timing(lookX, { toValue: 2.2, duration: 2000, easing: Easing.linear, useNativeDriver: true }),
+          Animated.timing(lookX, { toValue: -2.2, duration: 200, easing: Easing.in(Easing.quad), useNativeDriver: true }),
+        ]).start(({ finished }) => {
+          if (cancelled || !finished) return;
+          scan();
+        });
+      };
+      scan();
+
+      // Gentle slow blinks.
       const doBlink = () => {
         if (cancelled) return;
         quickBlink(() => {
           if (cancelled) return;
-          timers.push(setTimeout(doBlink, 1800 + Math.random() * 2200));
+          timers.push(setTimeout(doBlink, 2200 + Math.random() * 2200));
         });
       };
-      timers.push(setTimeout(doBlink, 1400));
+      timers.push(setTimeout(doBlink, 1600));
     }
 
     return () => {
       cancelled = true;
       timers.forEach(clearTimeout);
       loops.forEach((l) => l.stop());
+      // Halt any in-flight tweens so the next mood starts from a clean state
+      // (otherwise an interrupted yawn would never settle back).
+      blink.stopAnimation();
+      lookX.stopAnimation();
+      lookY.stopAnimation();
+      bounceY.stopAnimation();
+      scaleA.stopAnimation();
+      flat.stopAnimation();
     };
-  }, [mood, blink, lookX, lookY, bounceY, scaleA]);
+  }, [mood, blink, lookX, lookY, bounceY, scaleA, flat]);
+
+  const smileOpacity = flat.interpolate({ inputRange: [0, 1], outputRange: [1, 0] });
 
   return (
     <Animated.View style={[styles.face, { transform: [{ translateY: bounceY }, { scale: scaleA }] }]}>
@@ -189,7 +225,10 @@ function SmileyFace({ mood = "idle" }: { mood?: Mood }) {
         <Animated.View style={[styles.eye, { transform: [{ scaleY: blink }] }]} />
         <Animated.View style={[styles.eye, { transform: [{ scaleY: blink }] }]} />
       </Animated.View>
-      <View style={styles.mouth} />
+      <View style={styles.mouthWrap}>
+        <Animated.View style={[styles.mouth, { opacity: smileOpacity }]} />
+        <Animated.View style={[styles.mouthLine, { opacity: flat }]} />
+      </View>
     </Animated.View>
   );
 }
@@ -298,8 +337,15 @@ const styles = StyleSheet.create({
     borderRadius: 3.5,
     backgroundColor: GREEN,
   },
+  mouthWrap: {
+    width: 10,
+    height: 6,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   mouth: {
     // Small, gentle smile under the big eyes.
+    position: "absolute",
     width: 10,
     height: 6,
     borderColor: GREEN,
@@ -309,5 +355,13 @@ const styles = StyleSheet.create({
     borderBottomLeftRadius: 9,
     borderBottomRightRadius: 9,
     backgroundColor: "transparent",
+  },
+  mouthLine: {
+    // Neutral straight mouth while looking down.
+    position: "absolute",
+    width: 9,
+    height: 2,
+    borderRadius: 1,
+    backgroundColor: GREEN,
   },
 });

--- a/components/onboarding/ServerTerminal.tsx
+++ b/components/onboarding/ServerTerminal.tsx
@@ -64,80 +64,133 @@ function Led({ left, top, gid }: { left: number; top: number; gid: string }) {
   );
 }
 
-/** A little green face on the monitor: blinks and glances around now and then. */
-function SmileyFace() {
+export type Mood = "idle" | "excited" | "waiting";
+
+/** A little green face on the monitor. Its behaviour depends on `mood`:
+ *  - idle: blinks and glances around now and then
+ *  - excited: bounces and pulses with quick happy blinks
+ *  - waiting: looks down (at the loading text) and blinks slowly */
+function SmileyFace({ mood = "idle" }: { mood?: Mood }) {
   const blink = useRef(new Animated.Value(1)).current; // eye scaleY (1 = open)
   const lookX = useRef(new Animated.Value(0)).current;
   const lookY = useRef(new Animated.Value(0)).current;
+  const bounceY = useRef(new Animated.Value(0)).current;
+  const scaleA = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
     let cancelled = false;
-    let blinkTimer: ReturnType<typeof setTimeout>;
-    let lookTimer: ReturnType<typeof setTimeout>;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const loops: Animated.CompositeAnimation[] = [];
 
-    const doBlink = () => {
-      if (cancelled) return;
-      const seq: Animated.CompositeAnimation[] = [
-        Animated.timing(blink, { toValue: 0.1, duration: 80, useNativeDriver: true }),
-        Animated.timing(blink, { toValue: 1, duration: 90, useNativeDriver: true }),
-      ];
-      // occasional double blink
-      if (Math.random() < 0.35) {
-        seq.push(
-          Animated.delay(90),
-          Animated.timing(blink, { toValue: 0.1, duration: 80, useNativeDriver: true }),
-          Animated.timing(blink, { toValue: 1, duration: 90, useNativeDriver: true }),
-        );
-      }
-      Animated.sequence(seq).start(() => {
-        if (cancelled) return;
-        blinkTimer = setTimeout(doBlink, 1500 + Math.random() * 2800);
-      });
+    const quickBlink = (cb?: () => void) => {
+      Animated.sequence([
+        Animated.timing(blink, { toValue: 0.1, duration: 70, useNativeDriver: true }),
+        Animated.timing(blink, { toValue: 1, duration: 80, useNativeDriver: true }),
+      ]).start(cb);
     };
 
-    const doLook = () => {
-      if (cancelled) return;
-      const tx = (Math.random() * 2 - 1) * 3; // -3..3 px
-      const ty = (Math.random() * 2 - 1) * 1.2;
+    if (mood === "idle") {
       Animated.parallel([
-        Animated.timing(lookX, { toValue: tx, duration: 300, easing: Easing.out(Easing.ease), useNativeDriver: true }),
-        Animated.timing(lookY, { toValue: ty, duration: 300, easing: Easing.out(Easing.ease), useNativeDriver: true }),
-      ]).start(() => {
-        if (cancelled) return;
-        // hold the glance, then look back to centre
-        lookTimer = setTimeout(() => {
-          if (cancelled) return;
-          Animated.parallel([
-            Animated.timing(lookX, { toValue: 0, duration: 300, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
-            Animated.timing(lookY, { toValue: 0, duration: 300, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
-          ]).start(() => {
-            if (cancelled) return;
-            lookTimer = setTimeout(doLook, 2200 + Math.random() * 3000);
-          });
-        }, 650 + Math.random() * 900);
-      });
-    };
+        Animated.timing(lookY, { toValue: 0, duration: 200, useNativeDriver: true }),
+        Animated.timing(bounceY, { toValue: 0, duration: 200, useNativeDriver: true }),
+        Animated.timing(scaleA, { toValue: 1, duration: 200, useNativeDriver: true }),
+      ]).start();
 
-    blinkTimer = setTimeout(doBlink, 1200 + Math.random() * 1500);
-    lookTimer = setTimeout(doLook, 1800 + Math.random() * 1500);
+      const doBlink = () => {
+        if (cancelled) return;
+        quickBlink(() => {
+          if (cancelled) return;
+          timers.push(setTimeout(doBlink, 1500 + Math.random() * 2800));
+        });
+      };
+      const doLook = () => {
+        if (cancelled) return;
+        const tx = (Math.random() * 2 - 1) * 3;
+        const ty = (Math.random() * 2 - 1) * 1.2;
+        Animated.parallel([
+          Animated.timing(lookX, { toValue: tx, duration: 300, easing: Easing.out(Easing.ease), useNativeDriver: true }),
+          Animated.timing(lookY, { toValue: ty, duration: 300, easing: Easing.out(Easing.ease), useNativeDriver: true }),
+        ]).start(() => {
+          if (cancelled) return;
+          timers.push(
+            setTimeout(() => {
+              if (cancelled) return;
+              Animated.parallel([
+                Animated.timing(lookX, { toValue: 0, duration: 300, useNativeDriver: true }),
+                Animated.timing(lookY, { toValue: 0, duration: 300, useNativeDriver: true }),
+              ]).start(() => {
+                if (cancelled) return;
+                timers.push(setTimeout(doLook, 2200 + Math.random() * 3000));
+              });
+            }, 650 + Math.random() * 900),
+          );
+        });
+      };
+      timers.push(setTimeout(doBlink, 1200 + Math.random() * 1500));
+      timers.push(setTimeout(doLook, 1800 + Math.random() * 1500));
+    } else if (mood === "excited") {
+      Animated.parallel([
+        Animated.timing(lookX, { toValue: 0, duration: 150, useNativeDriver: true }),
+        Animated.timing(lookY, { toValue: -1, duration: 150, useNativeDriver: true }),
+      ]).start();
+      const bounce = Animated.loop(
+        Animated.sequence([
+          Animated.timing(bounceY, { toValue: -3, duration: 160, easing: Easing.out(Easing.quad), useNativeDriver: true }),
+          Animated.timing(bounceY, { toValue: 0, duration: 200, easing: Easing.in(Easing.quad), useNativeDriver: true }),
+        ]),
+      );
+      const pulse = Animated.loop(
+        Animated.sequence([
+          Animated.timing(scaleA, { toValue: 1.14, duration: 160, useNativeDriver: true }),
+          Animated.timing(scaleA, { toValue: 1, duration: 200, useNativeDriver: true }),
+        ]),
+      );
+      bounce.start();
+      pulse.start();
+      loops.push(bounce, pulse);
+
+      const doBlink = () => {
+        if (cancelled) return;
+        quickBlink(() => {
+          if (cancelled) return;
+          timers.push(setTimeout(() => !cancelled && quickBlink(), 140)); // double blink
+          timers.push(setTimeout(doBlink, 700 + Math.random() * 700));
+        });
+      };
+      timers.push(setTimeout(doBlink, 200));
+    } else {
+      // waiting — look down at the loading text and blink slowly
+      Animated.parallel([
+        Animated.timing(lookX, { toValue: 0, duration: 250, useNativeDriver: true }),
+        Animated.timing(lookY, { toValue: 3, duration: 380, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
+        Animated.timing(bounceY, { toValue: 1, duration: 300, useNativeDriver: true }),
+        Animated.timing(scaleA, { toValue: 1, duration: 200, useNativeDriver: true }),
+      ]).start();
+      const doBlink = () => {
+        if (cancelled) return;
+        quickBlink(() => {
+          if (cancelled) return;
+          timers.push(setTimeout(doBlink, 1800 + Math.random() * 2200));
+        });
+      };
+      timers.push(setTimeout(doBlink, 1400));
+    }
+
     return () => {
       cancelled = true;
-      clearTimeout(blinkTimer);
-      clearTimeout(lookTimer);
-      blink.stopAnimation();
-      lookX.stopAnimation();
-      lookY.stopAnimation();
+      timers.forEach(clearTimeout);
+      loops.forEach((l) => l.stop());
     };
-  }, [blink, lookX, lookY]);
+  }, [mood, blink, lookX, lookY, bounceY, scaleA]);
 
   return (
-    <View style={styles.face}>
+    <Animated.View style={[styles.face, { transform: [{ translateY: bounceY }, { scale: scaleA }] }]}>
       <Animated.View style={[styles.eyes, { transform: [{ translateX: lookX }, { translateY: lookY }] }]}>
         <Animated.View style={[styles.eye, { transform: [{ scaleY: blink }] }]} />
         <Animated.View style={[styles.eye, { transform: [{ scaleY: blink }] }]} />
       </Animated.View>
       <View style={styles.mouth} />
-    </View>
+    </Animated.View>
   );
 }
 
@@ -162,18 +215,21 @@ function TerminalText({ text }: { text: string }) {
 }
 
 /**
- * The server illustration with its little monitor. The panel shows the live
- * typed `label` (with a cursor) while typing, otherwise an animated green
- * smiley that blinks and looks around. Self-contained — drop it anywhere.
+ * The server illustration with its little monitor. While `mood` is "idle" the
+ * panel mirrors the live typed `label` (or an idle smiley when empty); other
+ * moods always show the smiley acting that mood. Self-contained — drop it anywhere.
  */
 export function ServerTerminal({
   style,
   label,
+  mood = "idle",
 }: {
   style?: StyleProp<ViewStyle>;
   label?: string;
+  mood?: Mood;
 }) {
   const hasText = (label ?? "").trim().length > 0;
+  const showText = mood === "idle" && hasText;
   return (
     <View style={[styles.imageContainer, style]}>
       <Image
@@ -182,7 +238,7 @@ export function ServerTerminal({
         contentFit="contain"
       />
       <View style={styles.screenRect}>
-        {hasText ? <TerminalText text={label ?? ""} /> : <SmileyFace />}
+        {showText ? <TerminalText text={label ?? ""} /> : <SmileyFace mood={mood} />}
       </View>
       <Led left={LED_POSITIONS.power.left} top={LED_POSITIONS.power.top} gid="power" />
       <Led left={LED_POSITIONS.status.left} top={LED_POSITIONS.status.top} gid="status" />


### PR DESCRIPTION
## What this is

Reworks the post-signup **vm-ready** screen into a single name → activate → live flow, wired to the real container provisioning backend.

### Flow
1. **Naming** — left-aligned "Give your Virtual Machine a name." with an animated server (smiley that blinks, looks around, reads the typed name on its monitor, and goes neutral/looks-down while waiting). The name field placeholder cycles through famous AI names (HAL 9000, JARVIS, R2-D2, WALL-E, Joshua, Bender) with a soft crossfade.
2. **Activating** — on **Activate now**, the server glides to centre and we run the **real provisioning** (`heartbeat` → poll → `requestContainer`, mirroring `vm-final`). Grass-themed loading messages shimmer with an Echo-Ring dot-matrix loader. The VM name is saved locally (AsyncStorage); it is not sent to the backend.
3. **Live** — once the backend confirms `container: running` + `grass: true`, we show a top-down confetti shower, "<name> is live!", a live telemetry strip (uptime / ping / CPU / RAM), and **Assign it's first task** → `vm-first-task`.

### Notable fixes
- Fixed an infinite loading loop (provisioning effect depended on `router`/`name`, whose identity changed on every re-render and cancelled the pending go-live).
- No-token and 40s hang-guards so the loader surfaces an error instead of spinning forever.

---

## ⚠️ Note for @Ayyappa — backend connections before "live"

**Please review the backend and wire up the agent/tool connections so they're established *before* we flip the VM to the "live" state.**

Context / where it stands today:
- The **only** gate for showing "live" right now is the container heartbeat returning `container: "running"` and `grass: true` (see the provisioning effect in [`app/onboarding/vm-ready.tsx`](app/onboarding/vm-ready.tsx)). That's the same logic `vm-final` uses.
- This does **not** verify that the VM's connections are set up — e.g. **GitHub** (`/github/verify`, `/github/oauth/status`), **Claude** (`/claude/status`), **Opencode** (`/opencode/status`). A user can reach "live" with an unconnected VM.
- The **telemetry numbers (uptime / ping / CPU / RAM) are currently simulated** on the client — there's no backend stream for them yet.

What we need from the backend:
1. Ensure that by the time the container reports `running` + `grass: true`, the **appropriate connections are provisioned/connected** server-side (or expose their readiness so the client can wait on them).
2. Ideally add a single readiness signal (or extend the heartbeat) that tells us "VM + connections are ready", so the client gates the "live" transition on the *connected* state, not just the container being up.
3. If real telemetry is available, expose it so we can replace the simulated values.

Happy to sync on the exact contract. For now the client treats "running + grass" as live and proceeds to first-task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)